### PR TITLE
Add ability to check pvStatus from CF and more preference settings

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,17 @@
 ####### Channel Finder location info #######
 cf.url=http://localhost:8080
-cf.resources=/ChannelFinder/resources/channels/
+cf.resources=/ChannelFinder/resources/channels?
+
+# Property names for the IOC IP address and PVA port
+cf.property.ioc_ip_address_name=iocIP
+cf.property.pva_port_name=pvaPort
+
+# Timeout in seconds for the ChannelFinder REST API
+cf.timeout=15
+
+# Whether to check if pvStatus is Active on CF searches
+cf.use_pvStatus=false
+
+####### PV Access Settings #######
+epics.pva.broadcast.port=5076
+epics.pva.server.port=5076


### PR DESCRIPTION
Adds some preference settings that seem like they could be useful. Feel free to comment if some aren't necessary though.

Also thought it could be useful to check the pvStatus field in CF on the initial query. Added a `cf.use_pvStatus`  preference setting and changed the CF query to use the channels bulk endpoint with query parameters. Could instead check the `pvStatus` field after the single channel query if you think that is better